### PR TITLE
[refactor] Card 내 Carousel 클릭할때는 상세페이지 이동 안하도록 수정

### DIFF
--- a/client/src/Components/Care/Card.tsx
+++ b/client/src/Components/Care/Card.tsx
@@ -9,6 +9,7 @@ const Card: React.FC<CardProps> = ({
   nickName,
   profileImgUrl,
   imgUrls,
+  onCardClick,
 }) => {
   return (
     <div className="m-4">
@@ -16,27 +17,29 @@ const Card: React.FC<CardProps> = ({
         <div className="mx-auto w-60">
           <Carousel imgUrls={imgUrls} />
         </div>
-        <div>
-          <button className="w-[7rem] h-7 bg-white shadow-sm shadow-gray-400 rounded-full mr-1">
-            {locationTag}
-          </button>
-          {petSize.map(size => (
-            <button
-              key={size}
-              className="w-[4rem] h-7 bg-white shadow-sm shadow-gray-400 rounded-full ml-1"
-            >
-              {size}
+        <div onClick={onCardClick}>
+          <div>
+            <button className="w-[7rem] h-7 bg-white shadow-sm shadow-gray-400 rounded-full mr-1">
+              {locationTag}
             </button>
-          ))}
-        </div>
-        <div className="mt-5">{title}</div>
-        <div className="flex justify-center items-center">
-          <img
-            className="w-8 h-8 rounded-full mr-2"
-            src={profileImgUrl}
-            alt={nickName}
-          />
-          <div className="mr-2">{nickName}</div>
+            {petSize.map(size => (
+              <button
+                key={size}
+                className="w-[4rem] h-7 bg-white shadow-sm shadow-gray-400 rounded-full ml-1"
+              >
+                {size}
+              </button>
+            ))}
+          </div>
+          <div className="mt-5">{title}</div>
+          <div className="flex justify-center items-center">
+            <img
+              className="w-8 h-8 rounded-full mr-2"
+              src={profileImgUrl}
+              alt={nickName}
+            />
+            <div className="mr-2">{nickName}</div>
+          </div>
         </div>
       </div>
     </div>

--- a/client/src/Components/User/MyLikes.tsx
+++ b/client/src/Components/User/MyLikes.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useGetUserLikes } from '../../Hook/useGetUserLikes';
 import Card from '../Care/Card';
 import PageBtns from './PageBtns';
+import { toCareListDetail } from '../../Util/navigateToCareListDetail';
 
 const MyLikes: React.FC<{ userId: string }> = ({ userId }) => {
   const [page, setPage] = useState<number>(1);
@@ -31,6 +32,9 @@ const MyLikes: React.FC<{ userId: string }> = ({ userId }) => {
               nickName={ele.nickName}
               profileImgUrl={ele.profileImgUrl}
               imgUrls={ele.imgUrls}
+              onCardClick={() => {
+                toCareListDetail;
+              }}
             />
           ))}
       </div>

--- a/client/src/Components/User/MyPost.tsx
+++ b/client/src/Components/User/MyPost.tsx
@@ -4,7 +4,7 @@ import { useGetMyPostToCare } from '../../Hook/useGetMyPostToCare';
 import Card from '../Care/Card';
 import { useGetMyPostToPeacock } from '../../Hook/useGetMyPostToPeacock';
 import PageBtns from './PageBtns';
-
+import { toCareListDetail } from '../../Util/navigateToCareListDetail';
 const MyPost: React.FC<{ userId: string }> = ({ userId }) => {
   const [category, setCategory] = useState<boolean>(true);
   const [page, setPage] = useState<number>(1);
@@ -35,19 +35,7 @@ const MyPost: React.FC<{ userId: string }> = ({ userId }) => {
       <div className="flex flex-wrap justify-center">
         {category ? (
           <>
-            {MyPostToCare &&
-              MyPostToCare.data.map((ele, idx) => (
-                // 추후 postId로 감싸는 div 추가할 것
-                <Card
-                  key={idx}
-                  title={ele.title}
-                  locationTag={ele.locationTag}
-                  petSize={ele.petSize}
-                  nickName={ele.nickName}
-                  profileImgUrl={ele.profileImgUrl}
-                  imgUrls={ele.imgUrls}
-                />
-              ))}
+
           </>
         ) : (
           <>
@@ -62,6 +50,7 @@ const MyPost: React.FC<{ userId: string }> = ({ userId }) => {
                   nickName={ele.nickName}
                   profileImgUrl={ele.profileImgUrl}
                   imgUrls={ele.imgUrls}
+                  onCardClick={() => {toCareListDetail}}
                 />
               ))}
           </>

--- a/client/src/Page/CareList.tsx
+++ b/client/src/Page/CareList.tsx
@@ -5,6 +5,7 @@ import Postcode from '../Components/Care/Postcode';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import InfiniteScroll from 'react-infinite-scroll-component';
+import { toCareListDetail } from '../Util/navigateToCareListDetail';
 
 interface Date {
   year: number;
@@ -143,6 +144,7 @@ const CareList = () => {
                     nickName={cardData.nickName}
                     profileImgUrl={cardData.profileImgUrl}
                     imgUrls={cardData.imgUrls}
+                    onCardClick={() => toCareListDetail(cardData.postId)}
                   />
                 </div>
               ))}

--- a/client/src/Util/navigateToCareListDetail.ts
+++ b/client/src/Util/navigateToCareListDetail.ts
@@ -1,0 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+const navigate = useNavigate();
+export const toCareListDetail = (postId: number) => {
+  navigate(`/carelistdetail/${postId}`);
+};

--- a/client/src/Util/types.ts
+++ b/client/src/Util/types.ts
@@ -51,6 +51,7 @@ export type CardProps = {
   nickName: string;
   profileImgUrl: string;
   imgUrls: string[];
+  onCardClick: () => void;
 };
 
 export interface UserPostType {


### PR DESCRIPTION
```
<Card
                    key={index}
                    title={cardData.title}
                    locationTag={cardData.locationTag}
                    petSize={cardData.petSizes}
                    nickName={cardData.nickName}
                    profileImgUrl={cardData.profileImgUrl}
                    imgUrls={cardData.imgUrls}
                    onCardClick={() => toCareListDetail(cardData.postId)}
                  />
```
맨밑에 props를 수정했으니 병합시 확인 바랍니다